### PR TITLE
Removed hardcoded Vagrant box URL

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,7 +1,6 @@
 Vagrant.configure(2)  do |config|
-  config.vm.box = "graylog2"
+  config.vm.box = "ubuntu/trusty64"
   config.vm.hostname = "graylog2"
-  config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
 
   config.vm.network :forwarded_port, guest: 9000, host: 9000
   config.vm.network :forwarded_port, guest: 12900, host: 12900


### PR DESCRIPTION
Having a custom box name and an hardcoded URL prevents Vagrant from using a cached version of the box. Using simple "ubuntu/trusty64" fixes that.
