### PR TITLE
admin password can be set with environmental variable GRAYLOG2_PASSWORD

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,4 +12,4 @@ RUN dpkg -i graylog2_latest.deb && \
 rm graylog2_latest.deb
 
 EXPOSE 12900
-CMD /opt/graylog2/embedded/bin/runsvdir-docker & graylog2-ctl reconfigure && tail -f /var/log/graylog2/server/current
+CMD /opt/graylog2/embedded/bin/runsvdir-docker & graylog2-ctl set-admin-password $GRAYLOG2_PASSWORD & graylog2-ctl reconfigure && tail -f /var/log/graylog2/server/current

--- a/docker/README.md
+++ b/docker/README.md
@@ -9,7 +9,7 @@ Copy the `Dockerfile` to a local folder and execute
 
 ```shell
 $ docker build -t graylog2 .
-$ docker run -t -p 9000:9000 -p 12201:12201 graylog2
+$ docker run -t -p 9000:9000 -p 12201:12201 -e GRAYLOG2_PASSWORD=admin graylog2
 ```
 
 This will create a container and runs Graylog2 in it.
@@ -19,4 +19,4 @@ Usage
 After downloading all software packages, your Graylog2 instance is ready to use.
 You can reach the web interface by pointing your browser to localhost: `http://localhost:9000`
 
-The default login is `Username: admin Password: admin`.
+The default login is `Username: admin Password: admin`. You can change password by setting environmental variable `GRAYLOG2_PASSWORD`


### PR DESCRIPTION
It is good to change default admin password when deploying production environments.
