### PR TITLE
Default admin password

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,4 +23,9 @@ EXPOSE 12201/udp
 # rest api
 EXPOSE 12900
 
-CMD /opt/graylog2/embedded/bin/runsvdir-docker & graylog2-ctl set-admin-password $GRAYLOG2_PASSWORD & graylog2-ctl reconfigure && tail -f /var/log/graylog2/server/current
+ENV GRAYLOG2_PASSWORD admin
+
+CMD /opt/graylog2/embedded/bin/runsvdir-docker & \
+    graylog2-ctl set-admin-password $GRAYLOG2_PASSWORD & \
+    graylog2-ctl reconfigure && \
+    tail -f /var/log/graylog2/server/current


### PR DESCRIPTION
Provides GRAYLOG2_PASSWORD env var in case if it is not passed on container creation.

And a bit more readable CMD instruction.
