### PR TITLE
elasticsearch shell scripts rely on JAVA_HOME

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,8 @@ MAINTAINER Marius Sturm <hello@torch.sh>
 
 ENV DEBIAN_FRONTEND noninteractive
 
+ENV JAVA_HOME /opt/graylog/embedded/jre
+
 RUN apt-get update && \
     apt-get install -y curl ntp ntpdate tzdata && \
     curl -O -L https://packages.graylog2.org/releases/graylog2-omnibus/ubuntu/graylog_latest.deb && \


### PR DESCRIPTION
Without JAVA_HOME env var set, elasticsearch plugin installs fail, as the elasticsearch shell script can't find java with `which java`.