### PR TITLE
add apt-get update before using the installer

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -12,6 +12,7 @@ Vagrant.configure(2)  do |config|
   end
 
   $script = <<SCRIPT
+    apt-get update
     echo 'Going to download Graylog...'
     curl -s -L -O https://packages.graylog2.org/releases/graylog2-omnibus/ubuntu/graylog_latest.deb
     dpkg -i graylog_latest.deb


### PR DESCRIPTION
if there is a security update of e.g. ntp the old debian package on the
server is not found anymore.

Run apt-get update before running chef fixes this.