### PR TITLE
Move owner changes from image build to start

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,7 +43,6 @@ RUN set -ex \
     ./data/config/scripts \
   ; do \
     mkdir -p "$path"; \
-    chown -R graylog:graylog "$path"; \
   done
 
 RUN set -x \

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -8,7 +8,13 @@ fi
 
 # Start Graylog server
 if [ "$1" = 'graylog' -a "$(id -u)" = '0' ]; then
-  set -- gosu graylog $JAVA_HOME/bin/java $GRAYLOG_SERVER_JAVA_OPTS \
+  for d in journal log plugin config config/scripts; do
+    dir=/usr/share/graylog/data/$d
+    if [ "$(stat --format='%U:%G' $dir)" != 'graylog:graylog' ]; then
+      chown -R graylog:graylog "$dir"
+    fi
+  done
+  set -- gosu graylog "$JAVA_HOME/bin/java" $GRAYLOG_SERVER_JAVA_OPTS \
       -jar \
       -Dlog4j.configuration=file:///usr/share/graylog/data/config/log4j2.xml \
       -Djava.library.path=/usr/share/graylog/lib/sigar/ \


### PR DESCRIPTION
As discussed on IRC, handle directory ownership changes in entrypoint in order to use less chmod 0777 in the wild.
