### PR TITLE
Changes the data volume to use an absolute path

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,7 +49,7 @@ RUN set -x \
 
 COPY config ./data/config
 
-VOLUME ./data
+VOLUME /usr/share/graylog/data
 
 COPY docker-entrypoint.sh /
 


### PR DESCRIPTION
Fixes #142 

According to the documentation: https://docs.docker.com/engine/userguide/containers/dockervolumes/

"The container-dir must always be an absolute path such as /src/docs. The host-dir can either be an absolute path or a name value."
