### PR TITLE
Remove config overrides for web_*

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,6 +49,6 @@ VOLUME /usr/share/graylog/data
 
 COPY docker-entrypoint.sh /
 
-EXPOSE 9000 12900
+EXPOSE 12900
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["graylog"]

--- a/docker/config/graylog.conf
+++ b/docker/config/graylog.conf
@@ -82,11 +82,11 @@ rest_listen_uri = http://0.0.0.0:12900/
 #web_enable = false
 
 # Web interface listen URI
-web_listen_uri = http://0.0.0.0:9000/
+#web_listen_uri = http://0.0.0.0:9000/
 
 # Enable CORS headers for the web interface. This is necessary for JS-clients accessing the server directly.
 # If these are disabled, modern browsers will not be able to retrieve resources from the server.
-web_enable_cors = true
+#web_enable_cors = true
 
 # Enable/disable GZIP support for the web interface. This compresses HTTP responses and therefore helps to reduce
 # overall round trip times. This is enabled by default. Uncomment the next line to disable it.


### PR DESCRIPTION
According to [the docs](https://github.com/Graylog2/graylog2-server/blob/2.1.0-beta.3/UPGRADING.rst#web-interface-listener), the web UI listener should start on http://0.0.0.0:12900/web by default. The settings in graylog.conf prevent this. The overridden settings in the Docker image should not change Graylog server default behavior as described in the docs.

I've also removed port 9000 from being exposed by default.

Related to https://github.com/Graylog2/graylog2-server/issues/2606.
