### PR TITLE
Fix rest_listen_uri and web_listen_uri use the same port in docker/config/graylog.conf #164

### DIFF
--- a/docker/config/graylog.conf
+++ b/docker/config/graylog.conf
@@ -35,7 +35,7 @@ plugin_dir = /usr/share/graylog/plugin
 
 # REST API listen URI. Must be reachable by other Graylog server nodes if you run a cluster.
 # When using Graylog Collectors, this URI will be used to receive heartbeat messages and must be accessible for all collectors.
-rest_listen_uri = http://0.0.0.0:9000/api/
+rest_listen_uri = http://0.0.0.0:12900/api/
 
 # REST API transport address. Defaults to the value of rest_listen_uri. Exception: If rest_listen_uri
 # is set to a wildcard IP address (0.0.0.0) the first non-loopback IPv4 system address is used.


### PR DESCRIPTION
Fix rest_listen_uri and web_listen_uri use the same port in docker/config/graylog.conf #164
