### PR TITLE
Change ownership of /usr/share/graylog in the Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,6 +47,9 @@ RUN set -ex \
 
 COPY config ./data/config
 
+RUN set -ex \
+  && chown -R graylog:graylog "/usr/share/graylog"
+
 VOLUME /usr/share/graylog/data
 
 COPY docker-entrypoint.sh /


### PR DESCRIPTION
This makes the permissions already clean directly in the image instead of relying on the entrypoint to fix things up.

It was a problem for me as I specified an alternate command in the image the permissions were not set by the entrypoint.

Maybe that section should be removed from the entrypoint now : 

```
  for d in journal log plugin config contentpacks; do
    dir="${DATA_DIR}/${d}"
    if [[ ! -d "$dir" ]]; then
      echo "Creating directory ${dir}"
      mkdir -p "$dir"
    fi
  done
```

As all this work is done in the Dockerfile now. I could add that to the current p-r.
