### PR TITLE
Adding support for modifying any graylog configuration using environment variables

### DIFF
--- a/docker/config/scripts/advanced_configuration.sh
+++ b/docker/config/scripts/advanced_configuration.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Configure minute details in graylog config using env variables with GL_CONF_
+# prefix
+#
+
+set -e
+
+source "/usr/share/graylog/data/config/scripts/global.sh"
+
+# Identify all env variables with GL_CONF_ prefix and update config
+for VAR in $(env); do
+    if [[ $VAR =~ ^GL_CONF_ ]]; then
+        gl_conf_name="$(echo "$VAR" | sed -r 's/^GL_CONF_([^=]*)=.*/\1/' | sed -e 's/__/./g' -e "s|^\s*||" -e "s|\s*$||" | tr '[:upper:]' '[:lower:]')"
+        gl_conf_value="$(echo "$VAR" | sed -r -e "s/^[^=]*=(.*)/\1/" -e "s|^\s*||" -e "s|\s*$||")"
+        update_config "${gl_conf_name}" "${gl_conf_value}"
+    fi
+done
+
+# Identify all env variables with GL_LOGLEVEL_ prefix and logging config
+for VAR in $(env); do
+    if [[ $VAR =~ ^GL_LOGLEVEL_ ]]; then
+        gl_loglevel_name="$(echo "$VAR" | sed -r 's/^GL_LOGLEVEL_([^=]*)=.*/\1/' | sed -e 's/__/./g' -e "s|^\s*||" -e "s|\s*$||" | tr '[:upper:]' '[:lower:]')"
+        gl_loglevel_value="$(echo "$VAR" | sed -r -e "s/^[^=]*=(.*)/\1/" -e "s|^\s*||" -e "s|\s*$||")"
+        update_loglevel "${gl_loglevel_value}" "${gl_loglevel_name}"
+    fi
+done

--- a/docker/config/scripts/configure_linked_containers.sh
+++ b/docker/config/scripts/configure_linked_containers.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Auto-configure graylog config if mongodb and elasticsearch docker containers
+# are linked
+#
+
+set -e
+
+source "/usr/share/graylog/data/config/scripts/global.sh"
+
+if [ ! -z "${MONGO_PORT_27017_TCP_ADDR}" ] && [ ! -z "${MONGO_PORT_27017_TCP_PORT}" ]; then
+    sed -i -e "s\mongodb_uri =.*$\mongodb_uri = mongodb://${MONGO_PORT_27017_TCP_ADDR}:${MONGO_PORT_27017_TCP_PORT}/graylog\\" ${CONFIG_FILE}
+fi
+
+if [ ! -z "${ELASTICSEARCH_PORT_9300_TCP_ADDR}" ] && [ ! -z "${ELASTICSEARCH_PORT_9300_TCP_PORT}" ]; then
+    update_config "elasticsearch_discovery_zen_ping_multicast_enabled" "false"
+    update_config "elasticsearch_discovery_zen_ping_unicast_hosts" "${ELASTICSEARCH_PORT_9300_TCP_ADDR}:${ELASTICSEARCH_PORT_9300_TCP_PORT}"
+    update_config "elasticsearch_config_file" "${ELASTICSEARCH_YML_FILE}"
+    update_config "elasticsearch_cluster_name" "elasticsearch"
+
+    # Create elasticsearch.yml file
+    cat > ${ELASTICSEARCH_YML_FILE} <<-EOF
+		cluster.name: elasticsearch
+		node.master: false
+		node.data: false
+		transport.tcp.port: 9350
+		http.enabled: false
+		discovery.zen.ping.multicast.enabled: false
+EOF
+    echo "discovery.zen.ping.unicast.hosts: [\"${ELASTICSEARCH_PORT_9300_TCP_ADDR}:${ELASTICSEARCH_PORT_9300_TCP_PORT}\"]" >> ${ELASTICSEARCH_YML_FILE}
+
+fi

--- a/docker/config/scripts/easy_configuration.sh
+++ b/docker/config/scripts/easy_configuration.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# Configure graylog based on friendly environment variable.
+#
+
+set -e
+
+source "/usr/share/graylog/data/config/scripts/global.sh"
+
+# Overwrite default http timeout
+update_config "http_connect_timeout" "10s"
+
+update_config "password_secret" "${GRAYLOG_SERVER_SECRET:=$(pwgen -s 96)}"
+update_config "rest_listen_uri" "http://0.0.0.0:12900/"
+update_config "web_listen_uri" "http://0.0.0.0:9000/"
+update_config "elasticsearch_network_host" "0.0.0.0"
+
+
+if [ ! -z "${GRAYLOG_IS_MASTER}" ]; then
+    update_config "is_master" "${GRAYLOG_IS_MASTER}"
+fi
+
+if [ ! -z "${GRAYLOG_PASSWORD}" ]; then
+    update_config "root_password_sha2" "$(echo -n ${GRAYLOG_PASSWORD} | sha256sum | awk '{print $1}')"
+fi
+
+if [ ! -z "${GRAYLOG_SMTP_SERVER}" ]; then
+    update_config "transport_email_enabled" "true"
+    update_config "transport_email_use_auth" "true"
+    update_config "transport_email_use_tls" "true"
+    update_config "transport_email_use_ssl" "true"
+    update_config "transport_email_subject_prefix" "[graylog]"
+    update_config "transport_email_hostname" "${GRAYLOG_SMTP_SERVER}"
+fi
+
+if [ ! -z "${GRAYLOG_SMTP_PORT}" ]; then
+    update_config "transport_email_port" "${GRAYLOG_SMTP_PORT}"
+fi
+if [ ! -z "${GRAYLOG_SMTP_USER}" ]; then
+    update_config "transport_email_auth_username" "${GRAYLOG_SMTP_USER}"
+fi
+if [ ! -z "${GRAYLOG_SMTP_PASSWORD}" ]; then
+    update_config "transport_email_auth_password" "${GRAYLOG_SMTP_PASSWORD}"
+fi
+
+if [ ! -z "${GRAYLOG_ES_SHARDS}" ]; then
+    update_config "elasticsearch_shards" "${GRAYLOG_ES_SHARDS}"
+fi
+
+if [ ! -z "${GRAYLOG_ES_REPLICAS}" ]; then
+    update_config "elasticsearch_replicas" "${GRAYLOG_ES_REPLICAS}"
+fi
+
+if [ ! -z "${GRAYLOG_ES_PREFIX}" ]; then
+    update_config "elasticsearch_index_prefix" "${GRAYLOG_ES_PREFIX}"
+fi
+
+if [ ! -z "${GRAYLOG_ES_CLUSTER}" ]; then
+    update_config "elasticsearch_cluster_name" "${GRAYLOG_ES_CLUSTER}"
+fi
+
+if [ ! -z "${GRAYLOG_ES_NODES}" ]; then
+    update_config "elasticsearch_discovery_zen_ping_multicast_enabled" "false"
+    update_config "elasticsearch_discovery_zen_ping_unicast_hosts" "${GRAYLOG_ES_NODES}"
+fi
+
+if [ ! -z "${GRAYLOG_MONGO_URI}" ]; then
+    update_config "mongodb_uri" "${GRAYLOG_MONGO_URI}"
+fi
+
+# Set heap to different value if specified
+if [ ! -z "${GRAYLOG_MEMORY}" ]; then
+    export GRAYLOG_SERVER_JAVA_OPTS="-Xms1g -Xmx${GRAYLOG_MEMORY} -XX:NewRatio=1 -server -XX:+ResizeTLAB -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled -XX:+UseParNewGC -XX:-OmitStackTraceInFastThrow"
+fi
+
+# Logging options
+if [ ! -z "${GRAYLOG_LOGLEVEL}" ]; then
+    update_loglevel "${GRAYLOG_LOGLEVEL}"
+fi
+
+# MaxMind db download URL for geolocation support
+if [ ! -z "${MAXMIND_DB_URL}" ]; then
+    cd /tmp
+    wget -q "${MAXMIND_DB_URL}"
+    filename="$(basename "${MAXMIND_DB_URL}")"
+    echo "Downloaded Maxmind DB - ${filename}"
+    if [ ${filename: -3} == ".gz" ]; then
+        gzip -d "${filename}"
+        echo "Decompressed Maxmind DB file - ${filename}"
+    fi
+    # Move db file to configured location
+    if [ ! -z "${GEOLOCATION_PATH}" ]; then
+        mv "${filename%.gz}" "${GEOLOCATION_PATH}"
+        echo "Moved maxmind DB to location ${GEOLOCATION_PATH}"
+    fi
+fi

--- a/docker/config/scripts/es_configuration.sh
+++ b/docker/config/scripts/es_configuration.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Configure elasticsearch based on info from server.conf
+#
+
+set -e
+
+source "/usr/share/graylog/data/config/scripts/global.sh"
+
+es_config_path="$(get_config elasticsearch_config_file)"
+if [ "X${es_config_path}" == "X" ]; then
+    es_config_path="${ELASTICSEARCH_YML_FILE}"
+    update_config "elasticsearch_config_file" "${ELASTICSEARCH_YML_FILE}"
+fi
+
+es_dir_path="$(dirname ${es_config_path})"
+if [ ! -d "${es_dir_path}" ]; then
+    mkdir -p "${es_dir_path}"
+fi
+
+if [ ! -f "${es_config_path}" ]; then
+    echo "cluster.name: $(get_config elasticsearch_cluster_name)" > "${es_config_path}"
+    echo "node.master: false" >> "${es_config_path}"
+    echo "node.data: false" >> "${es_config_path}"
+    if [ "X${HOST}" != "X" ]; then
+        echo "transport.tcp.port: ${PORT2}" >> "${es_config_path}"
+    else
+        echo "transport.tcp.port: 9350" >> "${es_config_path}"
+    fi
+    echo "http.enabled: false" >> "${es_config_path}"
+    echo "discovery.zen.ping.multicast.enabled: false" >> "${es_config_path}"
+    echo "discovery.zen.ping.unicast.hosts: $(get_config elasticsearch_discovery_zen_ping_unicast_hosts)" >> "${es_config_path}"
+    if [ "X${HOST}" != "X" ]; then
+        echo "network.bind_host: 0.0.0.0" >> "${es_config_path}"
+        echo "network.host: $(dig +short "${HOST}")" >> "${es_config_path}"
+    fi
+    if [ ! -z "${ES_INDEX_REFRESH_INTERVAL}" ]; then
+        echo "index.refresh_interval: ${ES_INDEX_REFRESH_INTERVAL}" >> "${es_config_path}"
+    fi
+fi

--- a/docker/config/scripts/global.sh
+++ b/docker/config/scripts/global.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Global variable and functions for scripts
+#
+
+set -e
+
+CONFIG_FILE="/usr/share/graylog/data/config/graylog.conf"
+ELASTICSEARCH_YML_FILE="/usr/share/graylog/data/config/elasticsearch.yml"
+LOG4J_FILE="/usr/share/graylog/data/config/log4j2.xml"
+
+update_config() {
+    ckey="${1}"
+    cvalue="${2}"
+    if grep "^\s*${ckey}\s*=.*$" ${CONFIG_FILE} >/dev/null; then
+        sed -i -e "s|^\s*${ckey}\s*=.*$|${ckey} = ${cvalue}|" ${CONFIG_FILE}
+    elif grep "^\s*#\s*${ckey}\s*=.*$" ${CONFIG_FILE} >/dev/null; then
+        sed -i -e "0,/^\s*#\s*${ckey}\s*=.*$/s||${ckey} = ${cvalue}|" ${CONFIG_FILE}
+    else
+        echo "${ckey} = ${cvalue}" >> ${CONFIG_FILE}
+    fi
+}
+
+get_config() {
+    # echo the value of config if it is defined
+    ckey="${1}"
+    grep "^\s*${ckey}\s*=.*$" ${CONFIG_FILE} | sed -e "s|^\s*${ckey}\s*=\(.*\)$|\1|" -e "s|^\s*||" -e "s|\s*$||"
+}
+
+update_loglevel() {
+    loglevel="${1}"
+    name="${2}"
+    if [ "X${loglevel}" == "X" ]; then
+        echo "ERROR - loglevel not specified!"
+        exit 1
+    fi
+    if [ "X${name}" == "X" ]; then
+        sed -i 's/ level="[^"]*"/ level="'"${loglevel}"'"/g' "${LOG4J_FILE}"
+    else
+        sed -i 's/name="'"${name}"'"\s* level="[^"]*"/name="'"${name}"'" level="'"${loglevel}"'"/g' "${LOG4J_FILE}"
+    fi
+}

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -20,6 +20,11 @@ if [ "$1" = 'graylog' -a "$(id -u)" = '0' ]; then
       chown -R graylog:graylog "$dir"
     fi
   done
+  # Custom configuration support
+  source "/usr/share/graylog/data/config/scripts/configure_linked_containers.sh"
+  source "/usr/share/graylog/data/config/scripts/easy_configuration.sh"
+  source "/usr/share/graylog/data/config/scripts/advanced_configuration.sh"
+  source "/usr/share/graylog/data/config/scripts/es_configuration.sh"
   # Start Graylog server
   set -- gosu graylog "$JAVA_HOME/bin/java" $GRAYLOG_SERVER_JAVA_OPTS \
       -jar \


### PR DESCRIPTION
This PR adds the following files:

* global.sh: Few bash functions and variables to be used by other scripts/
* easy_configuration.sh: Easy configuration of few common graylog configurations
* advanced_configuration.sh: Provides ability to modify any graylog configuration using GL_CONF_ prefix.
* configure_linked_containers.sh: Configures linked elasticsearch and mongodb IP+PORT details (docker --link) in graylog.conf
* es_configuration.sh: Creates elasticsearch.yml file for graylog as per config.
