### PR TITLE
Add USER instruction to Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,12 +45,15 @@ RUN set -ex \
     mkdir -p "$path"; \
   done
 
-COPY config ./data/config
+COPY config/* ./data/config/
+
+RUN chown -R graylog:graylog ./data
 
 VOLUME /usr/share/graylog/data
 
 COPY docker-entrypoint.sh /
 
-EXPOSE 9000 12900
+EXPOSE 9000 12900 12201 12201/udp
+USER root
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["graylog"]


### PR DESCRIPTION
Added `USER` instruction, updated file ownership and exposed common ports.

This docker image requires the root user to run it: Please see [line 13](https://github.com/Graylog2/graylog2-images/blob/2.3/docker/docker-entrypoint.sh#L13) in the `docker-entrypoint.sh` file:
```
if [ "$1" = 'graylog' -a "$(id -u)" = '0' ]; then
```
Because of the way the `docker-entrypoint.sh` file is written, the container will fail to boot up if it is run by any other user than root. Therefore, it is appropriate to set `USER root` instruction in the `Dockerfile`.
