### PR TITLE
Alpine-ize docker images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,37 +1,31 @@
-FROM java:8-jre
+FROM java:8-jre-alpine
 
 ARG GRAYLOG_VERSION
+ARG GRAYLOG_AWS_PLUGIN_VERSION
+ARG GRAYLOG_BEATS_PLUGIN_VERSION
+ARG GRAYLOG_METRICS_PROM_PLUGIN_VERSION
 
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/jre
+#ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/jre
 ENV GRAYLOG_SERVER_JAVA_OPTS "-Xms1g -Xmx2g -XX:NewRatio=1 -XX:MaxMetaspaceSize=256m -server -XX:+ResizeTLAB -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled -XX:+UseParNewGC -XX:-OmitStackTraceInFastThrow"
 ENV GOSU_VERSION 1.7
 
-RUN set -x \
-  && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
-  && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-  && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-  && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
-  && chmod +x /usr/local/bin/gosu \
-  && gosu nobody true
-
+RUN apk add --update su-exec openssl tar libcap \
+  && rm -rf /tmp/* /var/tmp/* /var/cache/apk/*
 
 RUN set -x \
-  && apt-get update \
-  && apt-get dist-upgrade -y \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN set -x \
-  && addgroup --gid 1100 graylog \
-  && adduser --disabled-password --disabled-login --gecos '' --uid 1100 --gid 1100 graylog \
+  && addgroup -g 1100 graylog \
+  && adduser -D -s /sbin/nologin -u 1100 -G graylog graylog \
   && mkdir /usr/share/graylog \
   && wget -O /usr/share/graylog.tgz "https://packages.graylog2.org/releases/graylog/graylog-${GRAYLOG_VERSION}.tgz" \
   && tar xfz /usr/share/graylog.tgz --strip-components=1 -C /usr/share/graylog \
+  && wget -O /usr/share/graylog/plugin/graylog-plugin-aws-${GRAYLOG_AWS_PLUGIN_VERSION}.jar https://github.com/graylog-labs/graylog-plugin-aws/releases/download/${GRAYLOG_AWS_PLUGIN_VERSION}/graylog-plugin-aws-${GRAYLOG_AWS_PLUGIN_VERSION}.jar \
+  && wget -O /usr/share/graylog/plugin/graylog-plugin-beats-${GRAYLOG_BEATS_PLUGIN_VERSION}.jar https://github.com/sivasamyk/graylog-beats-plugin/releases/download/v${GRAYLOG_BEATS_PLUGIN_VERSION}/graylog-input-beats-${GRAYLOG_BEATS_PLUGIN_VERSION}.jar \
+  && wget -O /usr/share/graylog/plugin/metrics-reporter-prometheus-${GRAYLOG_METRICS_PROM_PLUGIN_VERSION}.jar https://github.com/Graylog2/graylog-plugin-metrics-reporter/releases/download/${GRAYLOG_METRICS_PROM_PLUGIN_VERSION}/metrics-reporter-prometheus-${GRAYLOG_METRICS_PROM_PLUGIN_VERSION}.jar \
   && chown -R graylog:graylog /usr/share/graylog \
   && rm /usr/share/graylog.tgz \
   && setcap 'cap_net_bind_service=+ep' $JAVA_HOME/bin/java
 
+RUN wget -O - http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz | gzip -d - > /tmp/GeoLite2-City.mmdb
 
 ENV PATH /usr/share/graylog/bin:$PATH
 WORKDIR /usr/share/graylog
@@ -46,6 +40,7 @@ RUN set -ex \
   done
 
 COPY config ./data/config
+
 
 VOLUME /usr/share/graylog/data
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -21,7 +21,7 @@ if [ "$1" = 'graylog' -a "$(id -u)" = '0' ]; then
     fi
   done
   # Start Graylog server
-  set -- gosu graylog "$JAVA_HOME/bin/java" $GRAYLOG_SERVER_JAVA_OPTS \
+  set -- su-exec graylog "$JAVA_HOME/bin/java" $GRAYLOG_SERVER_JAVA_OPTS \
       -jar \
       -Dlog4j.configurationFile=/usr/share/graylog/data/config/log4j2.xml \
       -Djava.library.path=/usr/share/graylog/lib/sigar/ \


### PR DESCRIPTION
This shaves about 30% off the resulting image size and uses musl instead of glibc.