### PR TITLE
Update docker-entrypoint.sh

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -17,7 +17,7 @@ if [ "$1" = 'graylog' -a "$(id -u)" = '0' ]; then
       mkdir -p "$dir"
     fi
     if [ "$(stat --format='%U:%G' $dir)" != 'graylog:graylog' ]; then
-      chown -R graylog:graylog "$dir"
+      chown -R graylog:graylog "$dir" || echo "WARNING: Unable to change ownership of $dir"
     fi
   done
   # Start Graylog server


### PR DESCRIPTION
Allow entrypoint to continue even if `chown` fails on `/usr/share/graylog/data` directories. A warning is displayed, but subsequent error messages from the graylog server itself should be self explanatory about possible permission issues.

This should fix #215