### PR TITLE
Fix closing bracket in script that generated aws/README.md

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -9,17 +9,17 @@ AWS EC2 Images
 
 | Version   | Region         | AMI                   | Launch Wizard                                                                                                                      |
 | --------- | --------       | -----                 | -------------                                                                                                                      |
-| 3.0.2     | us-east-1      | ami-02e821869cb0548b1 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#LaunchInstanceWizard:ami=ami-02e821869cb0548b1       |
-| 3.0.2     | us-east-2      | ami-0dc9b20de7f000984 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-east-2#LaunchInstanceWizard:ami=ami-0dc9b20de7f000984       |
-| 3.0.2     | us-west-1      | ami-0150b70f22dc0afd2 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-west-1#LaunchInstanceWizard:ami=ami-0150b70f22dc0afd2       |
-| 3.0.2     | us-west-2      | ami-02ed992cb7d1c97e3 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-west-2#LaunchInstanceWizard:ami=ami-02ed992cb7d1c97e3       |
-| 3.0.2     | eu-west-1      | ami-064e6161c099b0047 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=eu-west-1#LaunchInstanceWizard:ami=ami-064e6161c099b0047       |
-| 3.0.2     | eu-west-2      | ami-046d1b2855cff4d70 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=eu-west-2#LaunchInstanceWizard:ami=ami-046d1b2855cff4d70       |
-| 3.0.2     | eu-west-3      | ami-0494f102259289d85 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=eu-west-3#LaunchInstanceWizard:ami=ami-0494f102259289d85       |
-| 3.0.2     | eu-central-1   | ami-0de6b9a8245dfdfe5 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=eu-central-1#LaunchInstanceWizard:ami=ami-0de6b9a8245dfdfe5    |
-| 3.0.2     | ap-northeast-1 | ami-04babc19332b03929 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=ap-northeast-1#LaunchInstanceWizard:ami=ami-04babc19332b03929  |
-| 3.0.2     | ap-southeast-1 | ami-093d0be4c6ca5d472 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=ap-southeast-1#LaunchInstanceWizard:ami=ami-093d0be4c6ca5d472  |
-| 3.0.2     | ap-southeast-2 | ami-0f640a0863a2b02b7 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=ap-southeast-2#LaunchInstanceWizard:ami=ami-0f640a0863a2b02b7  |
-| 3.0.2     | sa-east-1      | ami-0e614a0be4e7d1d94 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=sa-east-1#LaunchInstanceWizard:ami=ami-0e614a0be4e7d1d94       |
+| 3.0.2     | us-east-1      | ami-02e821869cb0548b1 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#LaunchInstanceWizard:ami=ami-02e821869cb0548b1)      |
+| 3.0.2     | us-east-2      | ami-0dc9b20de7f000984 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-east-2#LaunchInstanceWizard:ami=ami-0dc9b20de7f000984)      |
+| 3.0.2     | us-west-1      | ami-0150b70f22dc0afd2 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-west-1#LaunchInstanceWizard:ami=ami-0150b70f22dc0afd2)      |
+| 3.0.2     | us-west-2      | ami-02ed992cb7d1c97e3 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-west-2#LaunchInstanceWizard:ami=ami-02ed992cb7d1c97e3)      |
+| 3.0.2     | eu-west-1      | ami-064e6161c099b0047 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=eu-west-1#LaunchInstanceWizard:ami=ami-064e6161c099b0047)      |
+| 3.0.2     | eu-west-2      | ami-046d1b2855cff4d70 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=eu-west-2#LaunchInstanceWizard:ami=ami-046d1b2855cff4d70)      |
+| 3.0.2     | eu-west-3      | ami-0494f102259289d85 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=eu-west-3#LaunchInstanceWizard:ami=ami-0494f102259289d85)      |
+| 3.0.2     | eu-central-1   | ami-0de6b9a8245dfdfe5 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=eu-central-1#LaunchInstanceWizard:ami=ami-0de6b9a8245dfdfe5)   |
+| 3.0.2     | ap-northeast-1 | ami-04babc19332b03929 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=ap-northeast-1#LaunchInstanceWizard:ami=ami-04babc19332b03929) |
+| 3.0.2     | ap-southeast-1 | ami-093d0be4c6ca5d472 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=ap-southeast-1#LaunchInstanceWizard:ami=ami-093d0be4c6ca5d472) |
+| 3.0.2     | ap-southeast-2 | ami-0f640a0863a2b02b7 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=ap-southeast-2#LaunchInstanceWizard:ami=ami-0f640a0863a2b02b7) |
+| 3.0.2     | sa-east-1      | ami-0e614a0be4e7d1d94 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=sa-east-1#LaunchInstanceWizard:ami=ami-0e614a0be4e7d1d94)      |
 
 Detailed documentation can be found [here](http://docs.graylog.org/en/3.1/pages/installation/aws.html).

--- a/scripts/update-aws-ami.rb
+++ b/scripts/update-aws-ami.rb
@@ -45,7 +45,7 @@ readme = File.readlines(readme_file)
 readme.clone.each_with_index do |line, idx|
   images.each do |region, ami|
     if line.include?(region)
-      readme[idx].gsub!(/ami-\S+/, ami)
+      readme[idx].gsub!(/ami-\S+/, ami + ')')
       readme[idx].gsub!(/\d+\.\d+\.\d+/, version)
     end
   end


### PR DESCRIPTION
Fix closing bracket in script so it generates valid markdown links