### PR TITLE
Auto-update README with new AMI IDs after release.

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -9,7 +9,7 @@ AWS EC2 Images
 
 | Version   | Region         | AMI                   | Launch Wizard                                                                                                                      |
 | --------- | --------       | -----                 | -------------                                                                                                                      |
-| 3.3.2     | us-east-1      | ami-0b35f2808b17df079) | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#LaunchInstanceWizard:ami=ami-0b35f2808b17df079)      |
+| 3.3.2-1     | us-east-1      | ami-0d44082f0b224482d) | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#LaunchInstanceWizard:ami=ami-0d44082f0b224482d)      |
 | 3.3.2     | us-east-2      | ami-0e9b834d859a1129b) | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-east-2#LaunchInstanceWizard:ami=ami-0e9b834d859a1129b)      |
 | 3.3.2     | us-west-1      | ami-045a45a8d36fc72fb) | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-west-1#LaunchInstanceWizard:ami=ami-045a45a8d36fc72fb)      |
 | 3.3.2     | us-west-2      | ami-0fd202b1dc32dcbc3) | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-west-2#LaunchInstanceWizard:ami=ami-0fd202b1dc32dcbc3)      |

--- a/aws/README.md
+++ b/aws/README.md
@@ -9,19 +9,19 @@ AWS EC2 Images
 
 | Version   | Region         | AMI                   | Launch Wizard                                                                                                                      |
 | --------- | --------       | -----                 | -------------                                                                                                                      |
-| 3.3.2     | us-east-1      | ami-0b35f2808b17df079) | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#LaunchInstanceWizard:ami=ami-0b35f2808b17df079)      |
-| 3.3.2     | us-east-2      | ami-0e9b834d859a1129b) | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-east-2#LaunchInstanceWizard:ami=ami-0e9b834d859a1129b)      |
-| 3.3.2     | us-west-1      | ami-045a45a8d36fc72fb) | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-west-1#LaunchInstanceWizard:ami=ami-045a45a8d36fc72fb)      |
-| 3.3.2     | us-west-2      | ami-0fd202b1dc32dcbc3) | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-west-2#LaunchInstanceWizard:ami=ami-0fd202b1dc32dcbc3)      |
-| 3.3.2     | eu-west-1      | ami-087f79ab629f387f7) | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=eu-west-1#LaunchInstanceWizard:ami=ami-087f79ab629f387f7)      |
-| 3.3.2     | eu-west-2      | ami-081e856792d017e18) | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=eu-west-2#LaunchInstanceWizard:ami=ami-081e856792d017e18)      |
-| 3.3.2     | eu-west-3      | ami-016db4d9c08984af4) | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=eu-west-3#LaunchInstanceWizard:ami=ami-016db4d9c08984af4)      |
-| 3.3.2     | eu-central-1   | ami-0ac9b61b059e85c8f) | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=eu-central-1#LaunchInstanceWizard:ami=ami-0ac9b61b059e85c8f)   |
-| 3.3.2     | eu-north-1   | ami-0eee905b56ffd3e51) | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=eu-north-1#LaunchInstanceWizard:ami=ami-0eee905b56ffd3e51)   |
-| 3.3.2     | ap-northeast-1 | ami-040f9a690290d2811) | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=ap-northeast-1#LaunchInstanceWizard:ami=ami-040f9a690290d2811) |
-| 3.3.2     | ap-southeast-1 | ami-0c5705d8bbfa9a9a2) | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=ap-southeast-1#LaunchInstanceWizard:ami=ami-0c5705d8bbfa9a9a2) |
-| 3.3.2     | ap-southeast-2 | ami-0115ce0b1355b4718) | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=ap-southeast-2#LaunchInstanceWizard:ami=ami-0115ce0b1355b4718) |
-| 3.3.2     | sa-east-1      | ami-050f6549b9efa8103) | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=sa-east-1#LaunchInstanceWizard:ami=ami-050f6549b9efa8103)      |
-| 3.3.2     | ca-central-1   | ami-0fc4b7234ff09e7b0) | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=ca-central-1#LaunchInstanceWizard:ami=ami-0fc4b7234ff09e7b0)   |
+| 3.3.2     | us-east-1      | ami-0b35f2808b17df079 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#LaunchInstanceWizard:ami=ami-0b35f2808b17df079)      |
+| 3.3.2     | us-east-2      | ami-0e9b834d859a1129b | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-east-2#LaunchInstanceWizard:ami=ami-0e9b834d859a1129b)      |
+| 3.3.2     | us-west-1      | ami-045a45a8d36fc72fb | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-west-1#LaunchInstanceWizard:ami=ami-045a45a8d36fc72fb)      |
+| 3.3.2     | us-west-2      | ami-0fd202b1dc32dcbc3 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-west-2#LaunchInstanceWizard:ami=ami-0fd202b1dc32dcbc3)      |
+| 3.3.2     | eu-west-1      | ami-087f79ab629f387f7 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=eu-west-1#LaunchInstanceWizard:ami=ami-087f79ab629f387f7)      |
+| 3.3.2     | eu-west-2      | ami-081e856792d017e18 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=eu-west-2#LaunchInstanceWizard:ami=ami-081e856792d017e18)      |
+| 3.3.2     | eu-west-3      | ami-016db4d9c08984af4 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=eu-west-3#LaunchInstanceWizard:ami=ami-016db4d9c08984af4)      |
+| 3.3.2     | eu-central-1   | ami-0ac9b61b059e85c8f | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=eu-central-1#LaunchInstanceWizard:ami=ami-0ac9b61b059e85c8f)   |
+| 3.3.2     | eu-north-1   | ami-0eee905b56ffd3e51 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=eu-north-1#LaunchInstanceWizard:ami=ami-0eee905b56ffd3e51)   |
+| 3.3.2     | ap-northeast-1 | ami-040f9a690290d2811 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=ap-northeast-1#LaunchInstanceWizard:ami=ami-040f9a690290d2811) |
+| 3.3.2     | ap-southeast-1 | ami-0c5705d8bbfa9a9a2 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=ap-southeast-1#LaunchInstanceWizard:ami=ami-0c5705d8bbfa9a9a2) |
+| 3.3.2     | ap-southeast-2 | ami-0115ce0b1355b4718 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=ap-southeast-2#LaunchInstanceWizard:ami=ami-0115ce0b1355b4718) |
+| 3.3.2     | sa-east-1      | ami-050f6549b9efa8103 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=sa-east-1#LaunchInstanceWizard:ami=ami-050f6549b9efa8103)      |
+| 3.3.2     | ca-central-1   | ami-0fc4b7234ff09e7b0 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=ca-central-1#LaunchInstanceWizard:ami=ami-0fc4b7234ff09e7b0)   |
 
 Detailed documentation can be found [here](http://docs.graylog.org/en/3.2/pages/installation/aws.html).

--- a/aws/README.md
+++ b/aws/README.md
@@ -9,7 +9,7 @@ AWS EC2 Images
 
 | Version   | Region         | AMI                   | Launch Wizard                                                                                                                      |
 | --------- | --------       | -----                 | -------------                                                                                                                      |
-| 3.3.2-1     | us-east-1      | ami-0691bc3837fb063bd | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#LaunchInstanceWizard:ami=ami-0691bc3837fb063bd)      |
+| 3.3.2-1     | us-east-1      | ami-0b35f2808b17df079 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#LaunchInstanceWizard:ami=ami-0b35f2808b17df079)      |
 | 3.3.2     | us-east-2      | ami-0e9b834d859a1129b | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-east-2#LaunchInstanceWizard:ami=ami-0e9b834d859a1129b)      |
 | 3.3.2     | us-west-1      | ami-045a45a8d36fc72fb | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-west-1#LaunchInstanceWizard:ami=ami-045a45a8d36fc72fb)      |
 | 3.3.2     | us-west-2      | ami-0fd202b1dc32dcbc3 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-west-2#LaunchInstanceWizard:ami=ami-0fd202b1dc32dcbc3)      |

--- a/aws/README.md
+++ b/aws/README.md
@@ -9,7 +9,7 @@ AWS EC2 Images
 
 | Version   | Region         | AMI                   | Launch Wizard                                                                                                                      |
 | --------- | --------       | -----                 | -------------                                                                                                                      |
-| 3.3.2-1     | us-east-1      | ami-0d44082f0b224482d) | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#LaunchInstanceWizard:ami=ami-0d44082f0b224482d)      |
+| 3.3.2     | us-east-1      | ami-0b35f2808b17df079) | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#LaunchInstanceWizard:ami=ami-0b35f2808b17df079)    
 | 3.3.2     | us-east-2      | ami-0e9b834d859a1129b) | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-east-2#LaunchInstanceWizard:ami=ami-0e9b834d859a1129b)      |
 | 3.3.2     | us-west-1      | ami-045a45a8d36fc72fb) | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-west-1#LaunchInstanceWizard:ami=ami-045a45a8d36fc72fb)      |
 | 3.3.2     | us-west-2      | ami-0fd202b1dc32dcbc3) | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-west-2#LaunchInstanceWizard:ami=ami-0fd202b1dc32dcbc3)      |

--- a/aws/README.md
+++ b/aws/README.md
@@ -9,7 +9,7 @@ AWS EC2 Images
 
 | Version   | Region         | AMI                   | Launch Wizard                                                                                                                      |
 | --------- | --------       | -----                 | -------------                                                                                                                      |
-| 3.3.2     | us-east-1      | ami-0b35f2808b17df079 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#LaunchInstanceWizard:ami=ami-0b35f2808b17df079)      |
+| 3.3.2-1     | us-east-1      | ami-0691bc3837fb063bd | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#LaunchInstanceWizard:ami=ami-0691bc3837fb063bd)      |
 | 3.3.2     | us-east-2      | ami-0e9b834d859a1129b | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-east-2#LaunchInstanceWizard:ami=ami-0e9b834d859a1129b)      |
 | 3.3.2     | us-west-1      | ami-045a45a8d36fc72fb | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-west-1#LaunchInstanceWizard:ami=ami-045a45a8d36fc72fb)      |
 | 3.3.2     | us-west-2      | ami-0fd202b1dc32dcbc3 | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-west-2#LaunchInstanceWizard:ami=ami-0fd202b1dc32dcbc3)      |

--- a/aws/README.md
+++ b/aws/README.md
@@ -9,7 +9,7 @@ AWS EC2 Images
 
 | Version   | Region         | AMI                   | Launch Wizard                                                                                                                      |
 | --------- | --------       | -----                 | -------------                                                                                                                      |
-| 3.3.2     | us-east-1      | ami-0b35f2808b17df079) | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#LaunchInstanceWizard:ami=ami-0b35f2808b17df079)    
+| 3.3.2     | us-east-1      | ami-0b35f2808b17df079) | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#LaunchInstanceWizard:ami=ami-0b35f2808b17df079)      |
 | 3.3.2     | us-east-2      | ami-0e9b834d859a1129b) | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-east-2#LaunchInstanceWizard:ami=ami-0e9b834d859a1129b)      |
 | 3.3.2     | us-west-1      | ami-045a45a8d36fc72fb) | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-west-1#LaunchInstanceWizard:ami=ami-045a45a8d36fc72fb)      |
 | 3.3.2     | us-west-2      | ami-0fd202b1dc32dcbc3) | [Launch instance](https://console.aws.amazon.com/ec2/v2/home?region=us-west-2#LaunchInstanceWizard:ami=ami-0fd202b1dc32dcbc3)      |

--- a/packer/aws.json
+++ b/packer/aws.json
@@ -10,10 +10,10 @@
     "source_ami": "ami-920b10ed",
     "instance_type": "m3.medium",
     "ssh_username": "ubuntu",
-    "ami_name": "graylog-{{user `package_version`}}",
+    "ami_name": "graylog-{{user `package_version`}}-test",
     "ami_description": "Full-stack installation of Graylog - maintained by Graylog, Inc.",
     "ami_groups": ["all"],
-    "ami_regions": ["us-east-1", "us-east-2", "us-west-1", "us-west-2", "eu-west-1", "eu-west-2", "eu-west-3", "eu-central-1", "eu-north-1", "ap-northeast-1", "ap-southeast-1", "ap-southeast-2", "sa-east-1", "ca-central-1"],
+    "ami_regions": ["us-east-1"],
     "tags": {
       "OS_Version": "Ubuntu",
       "Release": "Latest"

--- a/packer/aws.json
+++ b/packer/aws.json
@@ -10,10 +10,10 @@
     "source_ami": "ami-920b10ed",
     "instance_type": "m3.medium",
     "ssh_username": "ubuntu",
-    "ami_name": "graylog-{{user `package_version`}}-test",
+    "ami_name": "graylog-{{user `package_version`}}",
     "ami_description": "Full-stack installation of Graylog - maintained by Graylog, Inc.",
     "ami_groups": ["all"],
-    "ami_regions": ["us-east-1"],
+    "ami_regions": ["us-east-1", "us-east-2", "us-west-1", "us-west-2", "eu-west-1", "eu-west-2", "eu-west-3", "eu-central-1", "eu-north-1", "ap-northeast-1", "ap-southeast-1", "ap-southeast-2", "sa-east-1", "ca-central-1"],
     "tags": {
       "OS_Version": "Ubuntu",
       "Release": "Latest"

--- a/scripts/jenkins.groovy
+++ b/scripts/jenkins.groovy
@@ -1,9 +1,3 @@
-if (currentBuild.buildCauses.toString().contains('BranchIndexingCause'))
-{
-  print "Build skipped due to trigger being Branch Indexing."
-  return
-}
-
 pipeline
 {
    agent none

--- a/scripts/jenkins.groovy
+++ b/scripts/jenkins.groovy
@@ -85,7 +85,7 @@ pipeline
                 }
               }
 
-              sh 'grep -A 30 "amazon-ebs: AMIs were created:" packer_output | grep -v "amazon-ebs: AMIs were created:" > ami-ids'
+              sh 'grep -A 30 "amazon-ebs: AMIs were created:" packer/packer_output | grep -v "amazon-ebs: AMIs were created:" > ami-ids'
               sh "scripts/update-aws-ami.rb packer/ami-ids $PACKAGE_VERSION"
               sh 'git add -u'
               sh 'git commit -m "Updating AMI IDs in README."'

--- a/scripts/jenkins.groovy
+++ b/scripts/jenkins.groovy
@@ -85,7 +85,7 @@ pipeline
                 }
               }
 
-              sh 'grep -A 30 "amazon-ebs: AMIs were created:" packer/packer_output | grep -v "amazon-ebs: AMIs were created:" > ami-ids'
+              sh 'grep -A 30 "amazon-ebs: AMIs were created:" packer/packer_output | grep -v "amazon-ebs: AMIs were created:" | sed '/^$/d' > ami-ids'
               sh "ruby scripts/update-aws-ami.rb ami-ids $PACKAGE_VERSION"
               sh 'git add -u'
               sh 'git commit -m "Updating AMI IDs in README."'

--- a/scripts/jenkins.groovy
+++ b/scripts/jenkins.groovy
@@ -85,7 +85,7 @@ pipeline
                 }
               }
 
-              sh 'grep -A 30 "amazon-ebs: AMIs were created:" packer/packer_output | grep -v "amazon-ebs: AMIs were created:" | sed '/^$/d' > ami-ids'
+              sh 'grep -A 30 "amazon-ebs: AMIs were created:" packer/packer_output | grep -v "amazon-ebs: AMIs were created:" | sed "/^$/d" > ami-ids'
               sh "ruby scripts/update-aws-ami.rb ami-ids $PACKAGE_VERSION"
               sh 'git add -u'
               sh 'git commit -m "Updating AMI IDs in README."'

--- a/scripts/jenkins.groovy
+++ b/scripts/jenkins.groovy
@@ -1,3 +1,9 @@
+if (currentBuild.buildCauses.toString().contains('BranchIndexingCause'))
+{
+  print "Build skipped due to trigger being Branch Indexing."
+  return
+}
+
 pipeline
 {
    agent none
@@ -65,7 +71,7 @@ pipeline
               validateParameters()
 
               echo "Checking out graylog2-images..."
-              checkout poll: false, scm: [$class: 'GitSCM', branches: [[name: "*/${params.BRANCH}"]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'LocalBranch', localBranch: "${params.BRANCH}"], [$class: 'WipeWorkspace']], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/Graylog2/graylog2-images.git']]]
+              checkout poll: false, scm: [$class: 'GitSCM', branches: [[name: "*/${params.BRANCH}"]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'LocalBranch', localBranch: "${params.BRANCH}"], [$class: 'WipeWorkspace']], submoduleCfg: [], userRemoteConfigs: [[url: 'git@github.com:Graylog2/graylog2-images.git']]]
 
               dir('packer')
               {

--- a/scripts/jenkins.groovy
+++ b/scripts/jenkins.groovy
@@ -86,7 +86,7 @@ pipeline
               }
 
               sh 'grep -A 30 "amazon-ebs: AMIs were created:" packer/packer_output | grep -v "amazon-ebs: AMIs were created:" > ami-ids'
-              sh "scripts/update-aws-ami.rb packer/ami-ids $PACKAGE_VERSION"
+              sh "ruby scripts/update-aws-ami.rb packer/ami-ids $PACKAGE_VERSION"
               sh 'git add -u'
               sh 'git commit -m "Updating AMI IDs in README."'
               sh "git push origin ${params.BRANCH}"

--- a/scripts/jenkins.groovy
+++ b/scripts/jenkins.groovy
@@ -86,7 +86,7 @@ pipeline
               }
 
               sh 'grep -A 30 "amazon-ebs: AMIs were created:" packer/packer_output | grep -v "amazon-ebs: AMIs were created:" > ami-ids'
-              sh "ruby scripts/update-aws-ami.rb packer/ami-ids $PACKAGE_VERSION"
+              sh "ruby scripts/update-aws-ami.rb ami-ids $PACKAGE_VERSION"
               sh 'git add -u'
               sh 'git commit -m "Updating AMI IDs in README."'
               sh "git push origin ${params.BRANCH}"

--- a/scripts/update-aws-ami.rb
+++ b/scripts/update-aws-ami.rb
@@ -45,7 +45,7 @@ readme = File.readlines(readme_file)
 readme.clone.each_with_index do |line, idx|
   images.each do |region, ami|
     if line.include?(region)
-      readme[idx].gsub!(/ami-\S+/, ami + ')')
+      readme[idx].gsub!(/ami-\w+/, ami)
       readme[idx].gsub!(/\d+\.\d+\.\d+/, version)
     end
   end


### PR DESCRIPTION
I don't like copy-pasting AMI-IDs after a release. This will make the Jenkins job do it for me. 